### PR TITLE
improve executeFile

### DIFF
--- a/src/cmds.ts
+++ b/src/cmds.ts
@@ -56,19 +56,24 @@ export function executeFile(ctx: Ctx): Cmd {
             vscode.window.showInformationMessage("No code found or selected.");
             return;
         }
+
+        // save before execution
         const isSaved = await util.saveDocument(document);
         if (!isSaved) {
             return;
         }
 
-        const runInTerminal = ctx.config.get("runInTerminal");
-        const clearPreviousOutput = ctx.config.get("clearPreviousOutput");
-        const preserveFocus = ctx.config.get("preserveFocus");
-        if (runInTerminal) {
-            ctx.executeFileInTerminal(document, clearPreviousOutput, preserveFocus);
-        } else {
-            ctx.executeFileInOutputChannel(document, clearPreviousOutput, preserveFocus);
-        }
+        const filePath = document.fileName.split("\\").join("/");
+        ctx.runText(`run ${filePath}`);
+
+        // const runInTerminal = ctx.config.get("runInTerminal");
+        // const clearPreviousOutput = ctx.config.get("clearPreviousOutput");
+        // const preserveFocus = ctx.config.get("preserveFocus");
+        // if (runInTerminal) {
+        //     ctx.executeFileInTerminal(document, clearPreviousOutput, preserveFocus);
+        // } else {
+        //     ctx.executeFileInOutputChannel(document, clearPreviousOutput, preserveFocus);
+        // }
     };
 }
 


### PR DESCRIPTION
I think it's simpler and more straightforward to execute a whole file by command `run <filename w/t .m>`  or simply `<filename w/o .m>` So I modified function `executeFile` in `cmds.ts` by myself. However, I'm not good at developing VSCode plugin. I believe there's better implementation for this function.

Bugs as far as I know:
- It doesn't work well for running scripts stored in a subfolder.