### PR TITLE
Add a path setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,12 @@
 					"type": "string",
 					"description": "Full path to the octave executable. By default searches the environment PATH variable",
 					"scope": "window"
+				},
+				"octave.alwaysUseAbsolutePaths" : {
+					"type": "boolean",
+					"default": false,
+					"description": "Running files in terminal will use absolute paths, instead of relative paths. Use for compatibility with files that change the working directory",
+					"scope": "window"
 				}
 			}
 		},

--- a/src/Ctx.ts
+++ b/src/Ctx.ts
@@ -120,10 +120,11 @@ export default class Ctx implements vscode.Disposable {
             vscode.commands.executeCommand("workbench.action.terminal.clear");
         }
 
+        const useAbsPath = this.config.get("alwaysUseAbsolutePaths");
         const filePath = document.fileName;
-        const wd = this._terminalStartingWd;
         let finalFilePath = filePath;
-        if (typeof wd === "string") {
+        const wd = this._terminalStartingWd;
+        if (!useAbsPath && typeof wd === "string") {
             finalFilePath = "./" + path.relative(wd, filePath);
         }
         finalFilePath = finalFilePath.split("\\").join("/");


### PR DESCRIPTION
Following from the work on using relative paths, it is necessary to deal with files that change the working directory of Octave. 

This setting provides an option for users needing that functionality at the cost of having to use absolute paths and, as of right now, having a worse terminal output.