### PR TITLE
Relative paths

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,7 +5,9 @@
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
-on: [pull_request]
+on: 
+  pull_request:
+    branches: [ "master" ]
 
 permissions:
   contents: read

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -102,6 +102,12 @@
 					"type": "string",
 					"description": "Full path to the octave executable. By default searches the environment PATH variable",
 					"scope": "window"
+				},
+				"octave.alwaysUseAbsolutePaths" : {
+					"type": "boolean",
+					"default": false,
+					"description": "Running files in terminal will use absolute paths, instead of relative paths. Use for compatibility with files that change the working directory",
+					"scope": "window"
 				}
 			}
 		},

--- a/src/Cfg.ts
+++ b/src/Cfg.ts
@@ -13,8 +13,8 @@ type ConfigFieldFull = keyof typeof settings;
 // You may want to add a default value for the setting in the package.json file.
 // Only then you will have automatic type checking for the setting.
 type ConfigFieldTypeDict = {
-    [key in ConfigFieldFull as key extends `${typeof globals.EXTENSION_NAME}.${infer R}` ? R : never]: // remove the "octave." prefix from the key
-    typeof settings[key] extends { default: infer R; } ? R : unknown
+    [key in ConfigFieldFull as key extends `${typeof globals.EXTENSION_NAME}.${infer SName}` ? SName : never]: // remove the "octave." prefix from the key
+    typeof settings[key] extends { default: infer SType; } ? SType : unknown
 };
 
 export type ConfigField = keyof ConfigFieldTypeDict;

--- a/src/Ctx.ts
+++ b/src/Ctx.ts
@@ -112,7 +112,8 @@ export default class Ctx implements vscode.Disposable {
         this.terminal?.sendText(code);
     };
 
-    public executeFileInTerminal(document: vscode.TextDocument, clearPreviousOutput: boolean, preserveFocus: boolean): void {
+    public executeFileInTerminal(document: vscode.TextDocument): void {
+        const clearPreviousOutput = this.config.get("clearPreviousOutput");
         if (clearPreviousOutput) {
             vscode.commands.executeCommand("workbench.action.terminal.clear");
         }
@@ -127,12 +128,14 @@ export default class Ctx implements vscode.Disposable {
         this.runText(command);
     }
 
-    public executeFileInOutputChannel(document: vscode.TextDocument, clearPreviousOutput: boolean, preserveFocus: boolean): void {
+    public executeFileInOutputChannel(document: vscode.TextDocument): void {
         const filePath = document.fileName.split("\\").join("/");
+        const clearPreviousOutput = this.config.get("clearPreviousOutput");
         if (clearPreviousOutput) {
             this._outputChannel.clear();
         }
         this.isRunning = true;
+        const preserveFocus =  this.config.get("preserveFocus")
         this._outputChannel.show(preserveFocus);
         this._outputChannel.appendLine(`[Running] ${path.basename(filePath)}`);
         this._outputChannel.appendLine("");

--- a/src/Ctx.ts
+++ b/src/Ctx.ts
@@ -120,10 +120,11 @@ export default class Ctx implements vscode.Disposable {
             vscode.commands.executeCommand("workbench.action.terminal.clear");
         }
 
+        const useAbsPath = this.config.get("alwaysUseAbsolutePaths");
         const filePath = document.fileName;
-        const wd = this._terminalStartingWd;
         let finalFilePath = filePath;
-        if (typeof wd === "string") {
+        const wd = this._terminalStartingWd;
+        if (!useAbsPath && typeof wd === "string") {
             finalFilePath = "./" + path.relative(wd, filePath);
         }
         finalFilePath = finalFilePath.split("\\").join("/");

--- a/src/cmds.ts
+++ b/src/cmds.ts
@@ -68,12 +68,10 @@ function executeFile(ctx: Ctx): Cmd {
         }
 
         const runInTerminal = ctx.config.get("runInTerminal");
-        const clearPreviousOutput = ctx.config.get("clearPreviousOutput");
-        const preserveFocus = ctx.config.get("preserveFocus");
         if (runInTerminal) {
-            ctx.executeFileInTerminal(document, clearPreviousOutput, preserveFocus);
+            ctx.executeFileInTerminal(document);
         } else {
-            ctx.executeFileInOutputChannel(document, clearPreviousOutput, preserveFocus);
+            ctx.executeFileInOutputChannel(document);
         }
     };
 }


### PR DESCRIPTION
1. Create a configuration setting for compatibility problems that may arise from 2 regarding directory changing octave files.
2. Use relative paths to execute them, instead of absolute ones that are more likely to contain non ASCII characters.
3. Update some CI stuff